### PR TITLE
♻️ Fix the broken dependency direction on provider

### DIFF
--- a/lib/data/auth/auth_repository_impl.dart
+++ b/lib/data/auth/auth_repository_impl.dart
@@ -1,11 +1,9 @@
 import 'package:dio/dio.dart';
 import 'package:flutter_best_practice/data/auth/auth_remote_data_source.dart';
-import 'package:flutter_best_practice/data/auth/auth_remote_data_source_impl.dart';
 import 'package:flutter_best_practice/data/auth/body/sign_up_request_body.dart';
 import 'package:flutter_best_practice/data/auth/entity/sign_in_entity.dart';
 import 'package:flutter_best_practice/domain/auth/auth_repository.dart';
 import 'package:flutter_best_practice/domain/auth/model/sign_in_model.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/helper/repository/repository.dart';
 import '../../core/helper/repository/repository_result.dart';
@@ -23,11 +21,6 @@ import 'mapper/auth_mapper.dart';
 - 에러 핸들링을 간편히 하기 위한 Repository class를 상속받고, domain에 있는 repository interface를 구현함
 - Provider를 통해 의존성 관리
  */
-
-final authRepositoryProvider = Provider((ref) {
-  return AuthRepositoryImpl(
-      authRemoteDataSource: ref.watch(authRemoteDataSourceProvider));
-});
 
 class AuthRepositoryImpl extends Repository implements AuthRepository {
   final AuthRemoteDataSource _authRemoteDataSource;

--- a/lib/domain/auth/auth_repository.dart
+++ b/lib/domain/auth/auth_repository.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_best_practice/domain/auth/params/sign_in_params.dart';
 import 'package:flutter_best_practice/domain/auth/params/sign_up_params.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/helper/repository/repository_result.dart';
 import 'model/sign_in_model.dart';
@@ -13,6 +14,10 @@ import 'model/sign_in_model.dart';
 사용법
 - usecase 요구사항에 맞춰 메서드를 정의하여 사용
  */
+final authRepositoryProvider = Provider<AuthRepository>((ref) {
+  throw Exception(
+      'You should provide your own implementation of [AuthRepository].');
+});
 
 abstract interface class AuthRepository {
   Future<RepositoryResult<SignInModel>> signIn({required SignInParams params});

--- a/lib/domain/auth/use_case/sign_in_use_case.dart
+++ b/lib/domain/auth/use_case/sign_in_use_case.dart
@@ -1,4 +1,3 @@
-import 'package:flutter_best_practice/data/auth/auth_repository_impl.dart';
 import 'package:flutter_best_practice/domain/auth/auth_repository.dart';
 import 'package:flutter_best_practice/domain/auth/model/sign_in_model.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -23,7 +22,7 @@ import '../params/sign_in_params.dart';
 
  */
 
-final signInUseCaseProvider = Provider((ref){
+final signInUseCaseProvider = Provider((ref) {
   return SignInUseCase(authRepository: ref.watch(authRepositoryProvider));
 });
 

--- a/lib/domain/auth/use_case/sign_up_use_case.dart
+++ b/lib/domain/auth/use_case/sign_up_use_case.dart
@@ -1,4 +1,3 @@
-import 'package:flutter_best_practice/data/auth/auth_repository_impl.dart';
 import 'package:flutter_best_practice/domain/auth/auth_repository.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -38,7 +37,8 @@ class SignUpUseCase implements UseCase<void, SignUpParams> {
     final resp = await _authRepository.signUp(params: params);
 
     return switch (resp) {
-      SuccessRepositoryResult<void>() => SuccessUseCaseResult<void>(data: null),
+      SuccessRepositoryResult<void>() =>
+        const SuccessUseCaseResult<void>(data: null),
       FailureRepositoryResult<void>() =>
         FailureUseCaseResult<void>(message: resp.messages?[0])
     };

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,11 +1,20 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_best_practice/manager/app/app_manager_impl.dart';
+import 'package:flutter_best_practice/data/auth/auth_remote_data_source_impl.dart';
+import 'package:flutter_best_practice/data/auth/auth_repository_impl.dart';
+import 'package:flutter_best_practice/domain/auth/auth_repository.dart';
 import 'package:flutter_best_practice/manager/router/app_router.dart';
-import 'package:flutter_best_practice/ui/auth/sign_in/sign_in_view.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 void main() {
-  runApp(const ProviderScope(child: MyApp()));
+  runApp(
+    ProviderScope(
+      overrides: [
+        authRepositoryProvider.overrideWith((ref) => AuthRepositoryImpl(
+            authRemoteDataSource: ref.watch(authRemoteDataSourceProvider))),
+      ],
+      child: const MyApp(),
+    ),
+  );
 }
 
 class MyApp extends ConsumerStatefulWidget {


### PR DESCRIPTION
# Description

모듈 별로 패키지가 따로 있다고 가정했을 때, 패키지간의 의존성을 지키는 `Provider.overrides` 사용 예제 입니다!

# Details

- `Provider` 선언을 인터페이스 선언 파일에서 수행합니다. 
- 구현체는 이전과 동일하게 구현합니다. 대신, 이곳에서는 Provider 를 선언하지 않습니다. 
- 이제 인터페이스에 의존하는 모든 코드는 인터페이스가 위치하는 코드와 같은 코드파일에 의존합니다. `import` 경로 의존성에서도 구현체에 대한 경로가 사라지게 됩니다. 
- 구현체는 앱 셋업 하는 시점에 `Provider.overrides` 를 활용하여 주입합니다.
- 구현체 코드에 대한 경로 참조는 모두 앱의 셋업 부분에만 존재하게 됩니다. 

# Pros

- 클래스 계층 구조상에서는 존재하지 않지만, 코드상에 약하게 남아있는 ui->data, domain->data 방향의 의존성이 모두 사라집니다. 

# Cons

- 프로젝트가 커지고 인터페이스가 많아질 수록, 그만큼 셋업 코드 부분의 의존성 주입을 위한 코드의 양이 늘어나게 됩니다. 