### PR TITLE
[Refactor] 에러 핸들링 로직 개선

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -9,6 +9,17 @@
 # packages, and plugins designed to encourage good coding practices.
 include: package:flutter_lints/flutter.yaml
 
+analyzer:
+  plugins:
+    - custom_lint
+  errors:
+    invalid_use_of_protected_member: error
+  exclude:
+    - "**.g.dart"
+    - "**.freezed.dart"
+    - "**_licenses.dart"
+    - "**.gen.dart"
+
 linter:
   # The lint rules applied to this project can be customized in the
   # section below to disable rules from the `package:flutter_lints/flutter.yaml`

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,11 @@
 targets:
   $default:
     builders:
-      source_gen|combining_builder:
+      source_gen:combining_builder:
         options:
           build_extensions:
             "^lib/{{dir}}/{{file_name}}.dart": "lib/{{dir}}/generated/{{file_name}}.g.dart"
+      freezed:
+        options:
+          build_extensions:
+            "^lib/{{dir}}/{{file_name}}.dart": "lib/{{dir}}/generated/{{file_name}}.freezed.dart"

--- a/lib/core/helper/api_call/api_call.dart
+++ b/lib/core/helper/api_call/api_call.dart
@@ -1,0 +1,37 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_best_practice/core/helper/error_handling/custom_exception.dart';
+import 'package:flutter_best_practice/core/helper/error_handling/error_model.dart';
+
+import '../result/result.dart';
+
+Future<Result<T, CustomException>> apiCall<T>(
+    {required Future<T> Function() task}) async {
+  try {
+    T value = await task();
+    return Success(data: value);
+  } on DioException catch (e) {
+    if (e.response == null || e.response!.data == null) {
+      return Failure(exception: UncaughtError(message: '알수 없는 에러입니다.'));
+    }
+
+    final errorModel = ErrorModel.fromJson(e.response!.data);
+
+    // return switch (errorModel.statusCode) {
+    //   401 =>
+    //     const Failure(exception: CustomException.unauthorized('접근이 제한되었습니다.')),
+    //   404 => const Failure(
+    //       exception: CustomException.productNotFound('상품이 존재하지 않습니다.')),
+    //   _ => Failure(
+    //       exception:
+    //           CustomException.unCaughtByFront('알수없는 에러입니다: ${e.toString()}'))
+    // };
+
+    return switch (errorModel.statusCode) {
+      401 => Failure(exception: UserNotFound(message: '해당하는 유저가 없습니다.')),
+      404 => Failure(exception: ProductNotFound(message: '상품이 존재하지 않습니다.')),
+      _ => Failure(exception: UncaughtError(message: e.toString()))
+    };
+  } catch (e) {
+    return Failure(exception: UncaughtError(message: e.toString()));
+  }
+}

--- a/lib/core/helper/error_handling/custom_exception.dart
+++ b/lib/core/helper/error_handling/custom_exception.dart
@@ -1,0 +1,35 @@
+sealed class CustomException implements Exception {
+  final String message;
+
+  const CustomException({
+    required this.message,
+  });
+}
+
+class UserNotFound extends CustomException {
+  UserNotFound({required super.message});
+}
+
+class ProductNotFound extends CustomException {
+  ProductNotFound({required super.message});
+}
+
+class Unauthorized extends CustomException {
+  Unauthorized({required super.message});
+}
+
+class UncaughtError extends CustomException {
+  UncaughtError({required super.message});
+}
+
+// 이렇게 하는 방법도 있습니다.
+// @freezed
+// class CustomException with _$CustomException implements Exception{
+//   const factory CustomException.unauthorized(String message) = _Unauthorized;
+//   const factory CustomException.userNotFound(String message) = _UserNotFound;
+//   const factory CustomException.tokenExpired(String message) = _TokenExpired;
+//   const factory CustomException.productNotFound(String message) = _ProductNotFound;
+//   const factory CustomException.missingRequiredValue(String message) = _MissingRequiredValue;
+//   const factory CustomException.unCaughtByFront(String message) = _UnCaughtByFront;
+//   const factory CustomException.invalid(String maessage) = _Invalid;
+// }

--- a/lib/core/helper/error_handling/error_model.dart
+++ b/lib/core/helper/error_handling/error_model.dart
@@ -1,0 +1,18 @@
+class ErrorModel {
+  final int statusCode;
+  final String message;
+
+  const ErrorModel({
+    required this.statusCode,
+    required this.message,
+  });
+
+  factory ErrorModel.fromJson(Map<String, dynamic> json) {
+
+    return ErrorModel(
+        statusCode: json['statusCode'],
+        message: json['message'] is List<String>
+            ? json['message'][0]
+            : json['message']);
+  }
+}

--- a/lib/core/helper/error_handling/generated/custom_exception.freezed.dart
+++ b/lib/core/helper/error_handling/generated/custom_exception.freezed.dart
@@ -1,0 +1,1252 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of '../custom_exception.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$CustomException {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(String message) unauthorized,
+    required TResult Function(String message) userNotFound,
+    required TResult Function(String message) tokenExpired,
+    required TResult Function(String message) productNotFound,
+    required TResult Function(String message) missingRequiredValue,
+    required TResult Function(String message) unCaughtByFront,
+    required TResult Function(String maessage) invalid,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(String message)? unauthorized,
+    TResult? Function(String message)? userNotFound,
+    TResult? Function(String message)? tokenExpired,
+    TResult? Function(String message)? productNotFound,
+    TResult? Function(String message)? missingRequiredValue,
+    TResult? Function(String message)? unCaughtByFront,
+    TResult? Function(String maessage)? invalid,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(String message)? unauthorized,
+    TResult Function(String message)? userNotFound,
+    TResult Function(String message)? tokenExpired,
+    TResult Function(String message)? productNotFound,
+    TResult Function(String message)? missingRequiredValue,
+    TResult Function(String message)? unCaughtByFront,
+    TResult Function(String maessage)? invalid,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Unauthorized value) unauthorized,
+    required TResult Function(_UserNotFound value) userNotFound,
+    required TResult Function(_TokenExpired value) tokenExpired,
+    required TResult Function(_ProductNotFound value) productNotFound,
+    required TResult Function(_MissingRequiredValue value) missingRequiredValue,
+    required TResult Function(_UnCaughtByFront value) unCaughtByFront,
+    required TResult Function(_Invalid value) invalid,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Unauthorized value)? unauthorized,
+    TResult? Function(_UserNotFound value)? userNotFound,
+    TResult? Function(_TokenExpired value)? tokenExpired,
+    TResult? Function(_ProductNotFound value)? productNotFound,
+    TResult? Function(_MissingRequiredValue value)? missingRequiredValue,
+    TResult? Function(_UnCaughtByFront value)? unCaughtByFront,
+    TResult? Function(_Invalid value)? invalid,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Unauthorized value)? unauthorized,
+    TResult Function(_UserNotFound value)? userNotFound,
+    TResult Function(_TokenExpired value)? tokenExpired,
+    TResult Function(_ProductNotFound value)? productNotFound,
+    TResult Function(_MissingRequiredValue value)? missingRequiredValue,
+    TResult Function(_UnCaughtByFront value)? unCaughtByFront,
+    TResult Function(_Invalid value)? invalid,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $CustomExceptionCopyWith<$Res> {
+  factory $CustomExceptionCopyWith(
+          CustomException value, $Res Function(CustomException) then) =
+      _$CustomExceptionCopyWithImpl<$Res, CustomException>;
+}
+
+/// @nodoc
+class _$CustomExceptionCopyWithImpl<$Res, $Val extends CustomException>
+    implements $CustomExceptionCopyWith<$Res> {
+  _$CustomExceptionCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+}
+
+/// @nodoc
+abstract class _$$UnauthorizedImplCopyWith<$Res> {
+  factory _$$UnauthorizedImplCopyWith(
+          _$UnauthorizedImpl value, $Res Function(_$UnauthorizedImpl) then) =
+      __$$UnauthorizedImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String message});
+}
+
+/// @nodoc
+class __$$UnauthorizedImplCopyWithImpl<$Res>
+    extends _$CustomExceptionCopyWithImpl<$Res, _$UnauthorizedImpl>
+    implements _$$UnauthorizedImplCopyWith<$Res> {
+  __$$UnauthorizedImplCopyWithImpl(
+      _$UnauthorizedImpl _value, $Res Function(_$UnauthorizedImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? message = null,
+  }) {
+    return _then(_$UnauthorizedImpl(
+      null == message
+          ? _value.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$UnauthorizedImpl implements _Unauthorized {
+  const _$UnauthorizedImpl(this.message);
+
+  @override
+  final String message;
+
+  @override
+  String toString() {
+    return 'CustomException.unauthorized(message: $message)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$UnauthorizedImpl &&
+            (identical(other.message, message) || other.message == message));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, message);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$UnauthorizedImplCopyWith<_$UnauthorizedImpl> get copyWith =>
+      __$$UnauthorizedImplCopyWithImpl<_$UnauthorizedImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(String message) unauthorized,
+    required TResult Function(String message) userNotFound,
+    required TResult Function(String message) tokenExpired,
+    required TResult Function(String message) productNotFound,
+    required TResult Function(String message) missingRequiredValue,
+    required TResult Function(String message) unCaughtByFront,
+    required TResult Function(String maessage) invalid,
+  }) {
+    return unauthorized(message);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(String message)? unauthorized,
+    TResult? Function(String message)? userNotFound,
+    TResult? Function(String message)? tokenExpired,
+    TResult? Function(String message)? productNotFound,
+    TResult? Function(String message)? missingRequiredValue,
+    TResult? Function(String message)? unCaughtByFront,
+    TResult? Function(String maessage)? invalid,
+  }) {
+    return unauthorized?.call(message);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(String message)? unauthorized,
+    TResult Function(String message)? userNotFound,
+    TResult Function(String message)? tokenExpired,
+    TResult Function(String message)? productNotFound,
+    TResult Function(String message)? missingRequiredValue,
+    TResult Function(String message)? unCaughtByFront,
+    TResult Function(String maessage)? invalid,
+    required TResult orElse(),
+  }) {
+    if (unauthorized != null) {
+      return unauthorized(message);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Unauthorized value) unauthorized,
+    required TResult Function(_UserNotFound value) userNotFound,
+    required TResult Function(_TokenExpired value) tokenExpired,
+    required TResult Function(_ProductNotFound value) productNotFound,
+    required TResult Function(_MissingRequiredValue value) missingRequiredValue,
+    required TResult Function(_UnCaughtByFront value) unCaughtByFront,
+    required TResult Function(_Invalid value) invalid,
+  }) {
+    return unauthorized(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Unauthorized value)? unauthorized,
+    TResult? Function(_UserNotFound value)? userNotFound,
+    TResult? Function(_TokenExpired value)? tokenExpired,
+    TResult? Function(_ProductNotFound value)? productNotFound,
+    TResult? Function(_MissingRequiredValue value)? missingRequiredValue,
+    TResult? Function(_UnCaughtByFront value)? unCaughtByFront,
+    TResult? Function(_Invalid value)? invalid,
+  }) {
+    return unauthorized?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Unauthorized value)? unauthorized,
+    TResult Function(_UserNotFound value)? userNotFound,
+    TResult Function(_TokenExpired value)? tokenExpired,
+    TResult Function(_ProductNotFound value)? productNotFound,
+    TResult Function(_MissingRequiredValue value)? missingRequiredValue,
+    TResult Function(_UnCaughtByFront value)? unCaughtByFront,
+    TResult Function(_Invalid value)? invalid,
+    required TResult orElse(),
+  }) {
+    if (unauthorized != null) {
+      return unauthorized(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _Unauthorized implements CustomException {
+  const factory _Unauthorized(final String message) = _$UnauthorizedImpl;
+
+  String get message;
+  @JsonKey(ignore: true)
+  _$$UnauthorizedImplCopyWith<_$UnauthorizedImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$UserNotFoundImplCopyWith<$Res> {
+  factory _$$UserNotFoundImplCopyWith(
+          _$UserNotFoundImpl value, $Res Function(_$UserNotFoundImpl) then) =
+      __$$UserNotFoundImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String message});
+}
+
+/// @nodoc
+class __$$UserNotFoundImplCopyWithImpl<$Res>
+    extends _$CustomExceptionCopyWithImpl<$Res, _$UserNotFoundImpl>
+    implements _$$UserNotFoundImplCopyWith<$Res> {
+  __$$UserNotFoundImplCopyWithImpl(
+      _$UserNotFoundImpl _value, $Res Function(_$UserNotFoundImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? message = null,
+  }) {
+    return _then(_$UserNotFoundImpl(
+      null == message
+          ? _value.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$UserNotFoundImpl implements _UserNotFound {
+  const _$UserNotFoundImpl(this.message);
+
+  @override
+  final String message;
+
+  @override
+  String toString() {
+    return 'CustomException.userNotFound(message: $message)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$UserNotFoundImpl &&
+            (identical(other.message, message) || other.message == message));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, message);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$UserNotFoundImplCopyWith<_$UserNotFoundImpl> get copyWith =>
+      __$$UserNotFoundImplCopyWithImpl<_$UserNotFoundImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(String message) unauthorized,
+    required TResult Function(String message) userNotFound,
+    required TResult Function(String message) tokenExpired,
+    required TResult Function(String message) productNotFound,
+    required TResult Function(String message) missingRequiredValue,
+    required TResult Function(String message) unCaughtByFront,
+    required TResult Function(String maessage) invalid,
+  }) {
+    return userNotFound(message);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(String message)? unauthorized,
+    TResult? Function(String message)? userNotFound,
+    TResult? Function(String message)? tokenExpired,
+    TResult? Function(String message)? productNotFound,
+    TResult? Function(String message)? missingRequiredValue,
+    TResult? Function(String message)? unCaughtByFront,
+    TResult? Function(String maessage)? invalid,
+  }) {
+    return userNotFound?.call(message);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(String message)? unauthorized,
+    TResult Function(String message)? userNotFound,
+    TResult Function(String message)? tokenExpired,
+    TResult Function(String message)? productNotFound,
+    TResult Function(String message)? missingRequiredValue,
+    TResult Function(String message)? unCaughtByFront,
+    TResult Function(String maessage)? invalid,
+    required TResult orElse(),
+  }) {
+    if (userNotFound != null) {
+      return userNotFound(message);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Unauthorized value) unauthorized,
+    required TResult Function(_UserNotFound value) userNotFound,
+    required TResult Function(_TokenExpired value) tokenExpired,
+    required TResult Function(_ProductNotFound value) productNotFound,
+    required TResult Function(_MissingRequiredValue value) missingRequiredValue,
+    required TResult Function(_UnCaughtByFront value) unCaughtByFront,
+    required TResult Function(_Invalid value) invalid,
+  }) {
+    return userNotFound(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Unauthorized value)? unauthorized,
+    TResult? Function(_UserNotFound value)? userNotFound,
+    TResult? Function(_TokenExpired value)? tokenExpired,
+    TResult? Function(_ProductNotFound value)? productNotFound,
+    TResult? Function(_MissingRequiredValue value)? missingRequiredValue,
+    TResult? Function(_UnCaughtByFront value)? unCaughtByFront,
+    TResult? Function(_Invalid value)? invalid,
+  }) {
+    return userNotFound?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Unauthorized value)? unauthorized,
+    TResult Function(_UserNotFound value)? userNotFound,
+    TResult Function(_TokenExpired value)? tokenExpired,
+    TResult Function(_ProductNotFound value)? productNotFound,
+    TResult Function(_MissingRequiredValue value)? missingRequiredValue,
+    TResult Function(_UnCaughtByFront value)? unCaughtByFront,
+    TResult Function(_Invalid value)? invalid,
+    required TResult orElse(),
+  }) {
+    if (userNotFound != null) {
+      return userNotFound(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _UserNotFound implements CustomException {
+  const factory _UserNotFound(final String message) = _$UserNotFoundImpl;
+
+  String get message;
+  @JsonKey(ignore: true)
+  _$$UserNotFoundImplCopyWith<_$UserNotFoundImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$TokenExpiredImplCopyWith<$Res> {
+  factory _$$TokenExpiredImplCopyWith(
+          _$TokenExpiredImpl value, $Res Function(_$TokenExpiredImpl) then) =
+      __$$TokenExpiredImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String message});
+}
+
+/// @nodoc
+class __$$TokenExpiredImplCopyWithImpl<$Res>
+    extends _$CustomExceptionCopyWithImpl<$Res, _$TokenExpiredImpl>
+    implements _$$TokenExpiredImplCopyWith<$Res> {
+  __$$TokenExpiredImplCopyWithImpl(
+      _$TokenExpiredImpl _value, $Res Function(_$TokenExpiredImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? message = null,
+  }) {
+    return _then(_$TokenExpiredImpl(
+      null == message
+          ? _value.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$TokenExpiredImpl implements _TokenExpired {
+  const _$TokenExpiredImpl(this.message);
+
+  @override
+  final String message;
+
+  @override
+  String toString() {
+    return 'CustomException.tokenExpired(message: $message)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$TokenExpiredImpl &&
+            (identical(other.message, message) || other.message == message));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, message);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$TokenExpiredImplCopyWith<_$TokenExpiredImpl> get copyWith =>
+      __$$TokenExpiredImplCopyWithImpl<_$TokenExpiredImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(String message) unauthorized,
+    required TResult Function(String message) userNotFound,
+    required TResult Function(String message) tokenExpired,
+    required TResult Function(String message) productNotFound,
+    required TResult Function(String message) missingRequiredValue,
+    required TResult Function(String message) unCaughtByFront,
+    required TResult Function(String maessage) invalid,
+  }) {
+    return tokenExpired(message);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(String message)? unauthorized,
+    TResult? Function(String message)? userNotFound,
+    TResult? Function(String message)? tokenExpired,
+    TResult? Function(String message)? productNotFound,
+    TResult? Function(String message)? missingRequiredValue,
+    TResult? Function(String message)? unCaughtByFront,
+    TResult? Function(String maessage)? invalid,
+  }) {
+    return tokenExpired?.call(message);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(String message)? unauthorized,
+    TResult Function(String message)? userNotFound,
+    TResult Function(String message)? tokenExpired,
+    TResult Function(String message)? productNotFound,
+    TResult Function(String message)? missingRequiredValue,
+    TResult Function(String message)? unCaughtByFront,
+    TResult Function(String maessage)? invalid,
+    required TResult orElse(),
+  }) {
+    if (tokenExpired != null) {
+      return tokenExpired(message);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Unauthorized value) unauthorized,
+    required TResult Function(_UserNotFound value) userNotFound,
+    required TResult Function(_TokenExpired value) tokenExpired,
+    required TResult Function(_ProductNotFound value) productNotFound,
+    required TResult Function(_MissingRequiredValue value) missingRequiredValue,
+    required TResult Function(_UnCaughtByFront value) unCaughtByFront,
+    required TResult Function(_Invalid value) invalid,
+  }) {
+    return tokenExpired(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Unauthorized value)? unauthorized,
+    TResult? Function(_UserNotFound value)? userNotFound,
+    TResult? Function(_TokenExpired value)? tokenExpired,
+    TResult? Function(_ProductNotFound value)? productNotFound,
+    TResult? Function(_MissingRequiredValue value)? missingRequiredValue,
+    TResult? Function(_UnCaughtByFront value)? unCaughtByFront,
+    TResult? Function(_Invalid value)? invalid,
+  }) {
+    return tokenExpired?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Unauthorized value)? unauthorized,
+    TResult Function(_UserNotFound value)? userNotFound,
+    TResult Function(_TokenExpired value)? tokenExpired,
+    TResult Function(_ProductNotFound value)? productNotFound,
+    TResult Function(_MissingRequiredValue value)? missingRequiredValue,
+    TResult Function(_UnCaughtByFront value)? unCaughtByFront,
+    TResult Function(_Invalid value)? invalid,
+    required TResult orElse(),
+  }) {
+    if (tokenExpired != null) {
+      return tokenExpired(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _TokenExpired implements CustomException {
+  const factory _TokenExpired(final String message) = _$TokenExpiredImpl;
+
+  String get message;
+  @JsonKey(ignore: true)
+  _$$TokenExpiredImplCopyWith<_$TokenExpiredImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$ProductNotFoundImplCopyWith<$Res> {
+  factory _$$ProductNotFoundImplCopyWith(_$ProductNotFoundImpl value,
+          $Res Function(_$ProductNotFoundImpl) then) =
+      __$$ProductNotFoundImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String message});
+}
+
+/// @nodoc
+class __$$ProductNotFoundImplCopyWithImpl<$Res>
+    extends _$CustomExceptionCopyWithImpl<$Res, _$ProductNotFoundImpl>
+    implements _$$ProductNotFoundImplCopyWith<$Res> {
+  __$$ProductNotFoundImplCopyWithImpl(
+      _$ProductNotFoundImpl _value, $Res Function(_$ProductNotFoundImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? message = null,
+  }) {
+    return _then(_$ProductNotFoundImpl(
+      null == message
+          ? _value.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$ProductNotFoundImpl implements _ProductNotFound {
+  const _$ProductNotFoundImpl(this.message);
+
+  @override
+  final String message;
+
+  @override
+  String toString() {
+    return 'CustomException.productNotFound(message: $message)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ProductNotFoundImpl &&
+            (identical(other.message, message) || other.message == message));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, message);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ProductNotFoundImplCopyWith<_$ProductNotFoundImpl> get copyWith =>
+      __$$ProductNotFoundImplCopyWithImpl<_$ProductNotFoundImpl>(
+          this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(String message) unauthorized,
+    required TResult Function(String message) userNotFound,
+    required TResult Function(String message) tokenExpired,
+    required TResult Function(String message) productNotFound,
+    required TResult Function(String message) missingRequiredValue,
+    required TResult Function(String message) unCaughtByFront,
+    required TResult Function(String maessage) invalid,
+  }) {
+    return productNotFound(message);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(String message)? unauthorized,
+    TResult? Function(String message)? userNotFound,
+    TResult? Function(String message)? tokenExpired,
+    TResult? Function(String message)? productNotFound,
+    TResult? Function(String message)? missingRequiredValue,
+    TResult? Function(String message)? unCaughtByFront,
+    TResult? Function(String maessage)? invalid,
+  }) {
+    return productNotFound?.call(message);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(String message)? unauthorized,
+    TResult Function(String message)? userNotFound,
+    TResult Function(String message)? tokenExpired,
+    TResult Function(String message)? productNotFound,
+    TResult Function(String message)? missingRequiredValue,
+    TResult Function(String message)? unCaughtByFront,
+    TResult Function(String maessage)? invalid,
+    required TResult orElse(),
+  }) {
+    if (productNotFound != null) {
+      return productNotFound(message);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Unauthorized value) unauthorized,
+    required TResult Function(_UserNotFound value) userNotFound,
+    required TResult Function(_TokenExpired value) tokenExpired,
+    required TResult Function(_ProductNotFound value) productNotFound,
+    required TResult Function(_MissingRequiredValue value) missingRequiredValue,
+    required TResult Function(_UnCaughtByFront value) unCaughtByFront,
+    required TResult Function(_Invalid value) invalid,
+  }) {
+    return productNotFound(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Unauthorized value)? unauthorized,
+    TResult? Function(_UserNotFound value)? userNotFound,
+    TResult? Function(_TokenExpired value)? tokenExpired,
+    TResult? Function(_ProductNotFound value)? productNotFound,
+    TResult? Function(_MissingRequiredValue value)? missingRequiredValue,
+    TResult? Function(_UnCaughtByFront value)? unCaughtByFront,
+    TResult? Function(_Invalid value)? invalid,
+  }) {
+    return productNotFound?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Unauthorized value)? unauthorized,
+    TResult Function(_UserNotFound value)? userNotFound,
+    TResult Function(_TokenExpired value)? tokenExpired,
+    TResult Function(_ProductNotFound value)? productNotFound,
+    TResult Function(_MissingRequiredValue value)? missingRequiredValue,
+    TResult Function(_UnCaughtByFront value)? unCaughtByFront,
+    TResult Function(_Invalid value)? invalid,
+    required TResult orElse(),
+  }) {
+    if (productNotFound != null) {
+      return productNotFound(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _ProductNotFound implements CustomException {
+  const factory _ProductNotFound(final String message) = _$ProductNotFoundImpl;
+
+  String get message;
+  @JsonKey(ignore: true)
+  _$$ProductNotFoundImplCopyWith<_$ProductNotFoundImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$MissingRequiredValueImplCopyWith<$Res> {
+  factory _$$MissingRequiredValueImplCopyWith(_$MissingRequiredValueImpl value,
+          $Res Function(_$MissingRequiredValueImpl) then) =
+      __$$MissingRequiredValueImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String message});
+}
+
+/// @nodoc
+class __$$MissingRequiredValueImplCopyWithImpl<$Res>
+    extends _$CustomExceptionCopyWithImpl<$Res, _$MissingRequiredValueImpl>
+    implements _$$MissingRequiredValueImplCopyWith<$Res> {
+  __$$MissingRequiredValueImplCopyWithImpl(_$MissingRequiredValueImpl _value,
+      $Res Function(_$MissingRequiredValueImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? message = null,
+  }) {
+    return _then(_$MissingRequiredValueImpl(
+      null == message
+          ? _value.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$MissingRequiredValueImpl implements _MissingRequiredValue {
+  const _$MissingRequiredValueImpl(this.message);
+
+  @override
+  final String message;
+
+  @override
+  String toString() {
+    return 'CustomException.missingRequiredValue(message: $message)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$MissingRequiredValueImpl &&
+            (identical(other.message, message) || other.message == message));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, message);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$MissingRequiredValueImplCopyWith<_$MissingRequiredValueImpl>
+      get copyWith =>
+          __$$MissingRequiredValueImplCopyWithImpl<_$MissingRequiredValueImpl>(
+              this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(String message) unauthorized,
+    required TResult Function(String message) userNotFound,
+    required TResult Function(String message) tokenExpired,
+    required TResult Function(String message) productNotFound,
+    required TResult Function(String message) missingRequiredValue,
+    required TResult Function(String message) unCaughtByFront,
+    required TResult Function(String maessage) invalid,
+  }) {
+    return missingRequiredValue(message);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(String message)? unauthorized,
+    TResult? Function(String message)? userNotFound,
+    TResult? Function(String message)? tokenExpired,
+    TResult? Function(String message)? productNotFound,
+    TResult? Function(String message)? missingRequiredValue,
+    TResult? Function(String message)? unCaughtByFront,
+    TResult? Function(String maessage)? invalid,
+  }) {
+    return missingRequiredValue?.call(message);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(String message)? unauthorized,
+    TResult Function(String message)? userNotFound,
+    TResult Function(String message)? tokenExpired,
+    TResult Function(String message)? productNotFound,
+    TResult Function(String message)? missingRequiredValue,
+    TResult Function(String message)? unCaughtByFront,
+    TResult Function(String maessage)? invalid,
+    required TResult orElse(),
+  }) {
+    if (missingRequiredValue != null) {
+      return missingRequiredValue(message);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Unauthorized value) unauthorized,
+    required TResult Function(_UserNotFound value) userNotFound,
+    required TResult Function(_TokenExpired value) tokenExpired,
+    required TResult Function(_ProductNotFound value) productNotFound,
+    required TResult Function(_MissingRequiredValue value) missingRequiredValue,
+    required TResult Function(_UnCaughtByFront value) unCaughtByFront,
+    required TResult Function(_Invalid value) invalid,
+  }) {
+    return missingRequiredValue(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Unauthorized value)? unauthorized,
+    TResult? Function(_UserNotFound value)? userNotFound,
+    TResult? Function(_TokenExpired value)? tokenExpired,
+    TResult? Function(_ProductNotFound value)? productNotFound,
+    TResult? Function(_MissingRequiredValue value)? missingRequiredValue,
+    TResult? Function(_UnCaughtByFront value)? unCaughtByFront,
+    TResult? Function(_Invalid value)? invalid,
+  }) {
+    return missingRequiredValue?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Unauthorized value)? unauthorized,
+    TResult Function(_UserNotFound value)? userNotFound,
+    TResult Function(_TokenExpired value)? tokenExpired,
+    TResult Function(_ProductNotFound value)? productNotFound,
+    TResult Function(_MissingRequiredValue value)? missingRequiredValue,
+    TResult Function(_UnCaughtByFront value)? unCaughtByFront,
+    TResult Function(_Invalid value)? invalid,
+    required TResult orElse(),
+  }) {
+    if (missingRequiredValue != null) {
+      return missingRequiredValue(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _MissingRequiredValue implements CustomException {
+  const factory _MissingRequiredValue(final String message) =
+      _$MissingRequiredValueImpl;
+
+  String get message;
+  @JsonKey(ignore: true)
+  _$$MissingRequiredValueImplCopyWith<_$MissingRequiredValueImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$UnCaughtByFrontImplCopyWith<$Res> {
+  factory _$$UnCaughtByFrontImplCopyWith(_$UnCaughtByFrontImpl value,
+          $Res Function(_$UnCaughtByFrontImpl) then) =
+      __$$UnCaughtByFrontImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String message});
+}
+
+/// @nodoc
+class __$$UnCaughtByFrontImplCopyWithImpl<$Res>
+    extends _$CustomExceptionCopyWithImpl<$Res, _$UnCaughtByFrontImpl>
+    implements _$$UnCaughtByFrontImplCopyWith<$Res> {
+  __$$UnCaughtByFrontImplCopyWithImpl(
+      _$UnCaughtByFrontImpl _value, $Res Function(_$UnCaughtByFrontImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? message = null,
+  }) {
+    return _then(_$UnCaughtByFrontImpl(
+      null == message
+          ? _value.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$UnCaughtByFrontImpl implements _UnCaughtByFront {
+  const _$UnCaughtByFrontImpl(this.message);
+
+  @override
+  final String message;
+
+  @override
+  String toString() {
+    return 'CustomException.unCaughtByFront(message: $message)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$UnCaughtByFrontImpl &&
+            (identical(other.message, message) || other.message == message));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, message);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$UnCaughtByFrontImplCopyWith<_$UnCaughtByFrontImpl> get copyWith =>
+      __$$UnCaughtByFrontImplCopyWithImpl<_$UnCaughtByFrontImpl>(
+          this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(String message) unauthorized,
+    required TResult Function(String message) userNotFound,
+    required TResult Function(String message) tokenExpired,
+    required TResult Function(String message) productNotFound,
+    required TResult Function(String message) missingRequiredValue,
+    required TResult Function(String message) unCaughtByFront,
+    required TResult Function(String maessage) invalid,
+  }) {
+    return unCaughtByFront(message);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(String message)? unauthorized,
+    TResult? Function(String message)? userNotFound,
+    TResult? Function(String message)? tokenExpired,
+    TResult? Function(String message)? productNotFound,
+    TResult? Function(String message)? missingRequiredValue,
+    TResult? Function(String message)? unCaughtByFront,
+    TResult? Function(String maessage)? invalid,
+  }) {
+    return unCaughtByFront?.call(message);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(String message)? unauthorized,
+    TResult Function(String message)? userNotFound,
+    TResult Function(String message)? tokenExpired,
+    TResult Function(String message)? productNotFound,
+    TResult Function(String message)? missingRequiredValue,
+    TResult Function(String message)? unCaughtByFront,
+    TResult Function(String maessage)? invalid,
+    required TResult orElse(),
+  }) {
+    if (unCaughtByFront != null) {
+      return unCaughtByFront(message);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Unauthorized value) unauthorized,
+    required TResult Function(_UserNotFound value) userNotFound,
+    required TResult Function(_TokenExpired value) tokenExpired,
+    required TResult Function(_ProductNotFound value) productNotFound,
+    required TResult Function(_MissingRequiredValue value) missingRequiredValue,
+    required TResult Function(_UnCaughtByFront value) unCaughtByFront,
+    required TResult Function(_Invalid value) invalid,
+  }) {
+    return unCaughtByFront(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Unauthorized value)? unauthorized,
+    TResult? Function(_UserNotFound value)? userNotFound,
+    TResult? Function(_TokenExpired value)? tokenExpired,
+    TResult? Function(_ProductNotFound value)? productNotFound,
+    TResult? Function(_MissingRequiredValue value)? missingRequiredValue,
+    TResult? Function(_UnCaughtByFront value)? unCaughtByFront,
+    TResult? Function(_Invalid value)? invalid,
+  }) {
+    return unCaughtByFront?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Unauthorized value)? unauthorized,
+    TResult Function(_UserNotFound value)? userNotFound,
+    TResult Function(_TokenExpired value)? tokenExpired,
+    TResult Function(_ProductNotFound value)? productNotFound,
+    TResult Function(_MissingRequiredValue value)? missingRequiredValue,
+    TResult Function(_UnCaughtByFront value)? unCaughtByFront,
+    TResult Function(_Invalid value)? invalid,
+    required TResult orElse(),
+  }) {
+    if (unCaughtByFront != null) {
+      return unCaughtByFront(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _UnCaughtByFront implements CustomException {
+  const factory _UnCaughtByFront(final String message) = _$UnCaughtByFrontImpl;
+
+  String get message;
+  @JsonKey(ignore: true)
+  _$$UnCaughtByFrontImplCopyWith<_$UnCaughtByFrontImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$InvalidImplCopyWith<$Res> {
+  factory _$$InvalidImplCopyWith(
+          _$InvalidImpl value, $Res Function(_$InvalidImpl) then) =
+      __$$InvalidImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String maessage});
+}
+
+/// @nodoc
+class __$$InvalidImplCopyWithImpl<$Res>
+    extends _$CustomExceptionCopyWithImpl<$Res, _$InvalidImpl>
+    implements _$$InvalidImplCopyWith<$Res> {
+  __$$InvalidImplCopyWithImpl(
+      _$InvalidImpl _value, $Res Function(_$InvalidImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? maessage = null,
+  }) {
+    return _then(_$InvalidImpl(
+      null == maessage
+          ? _value.maessage
+          : maessage // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$InvalidImpl implements _Invalid {
+  const _$InvalidImpl(this.maessage);
+
+  @override
+  final String maessage;
+
+  @override
+  String toString() {
+    return 'CustomException.invalid(maessage: $maessage)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$InvalidImpl &&
+            (identical(other.maessage, maessage) ||
+                other.maessage == maessage));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, maessage);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$InvalidImplCopyWith<_$InvalidImpl> get copyWith =>
+      __$$InvalidImplCopyWithImpl<_$InvalidImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(String message) unauthorized,
+    required TResult Function(String message) userNotFound,
+    required TResult Function(String message) tokenExpired,
+    required TResult Function(String message) productNotFound,
+    required TResult Function(String message) missingRequiredValue,
+    required TResult Function(String message) unCaughtByFront,
+    required TResult Function(String maessage) invalid,
+  }) {
+    return invalid(maessage);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(String message)? unauthorized,
+    TResult? Function(String message)? userNotFound,
+    TResult? Function(String message)? tokenExpired,
+    TResult? Function(String message)? productNotFound,
+    TResult? Function(String message)? missingRequiredValue,
+    TResult? Function(String message)? unCaughtByFront,
+    TResult? Function(String maessage)? invalid,
+  }) {
+    return invalid?.call(maessage);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(String message)? unauthorized,
+    TResult Function(String message)? userNotFound,
+    TResult Function(String message)? tokenExpired,
+    TResult Function(String message)? productNotFound,
+    TResult Function(String message)? missingRequiredValue,
+    TResult Function(String message)? unCaughtByFront,
+    TResult Function(String maessage)? invalid,
+    required TResult orElse(),
+  }) {
+    if (invalid != null) {
+      return invalid(maessage);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Unauthorized value) unauthorized,
+    required TResult Function(_UserNotFound value) userNotFound,
+    required TResult Function(_TokenExpired value) tokenExpired,
+    required TResult Function(_ProductNotFound value) productNotFound,
+    required TResult Function(_MissingRequiredValue value) missingRequiredValue,
+    required TResult Function(_UnCaughtByFront value) unCaughtByFront,
+    required TResult Function(_Invalid value) invalid,
+  }) {
+    return invalid(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Unauthorized value)? unauthorized,
+    TResult? Function(_UserNotFound value)? userNotFound,
+    TResult? Function(_TokenExpired value)? tokenExpired,
+    TResult? Function(_ProductNotFound value)? productNotFound,
+    TResult? Function(_MissingRequiredValue value)? missingRequiredValue,
+    TResult? Function(_UnCaughtByFront value)? unCaughtByFront,
+    TResult? Function(_Invalid value)? invalid,
+  }) {
+    return invalid?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Unauthorized value)? unauthorized,
+    TResult Function(_UserNotFound value)? userNotFound,
+    TResult Function(_TokenExpired value)? tokenExpired,
+    TResult Function(_ProductNotFound value)? productNotFound,
+    TResult Function(_MissingRequiredValue value)? missingRequiredValue,
+    TResult Function(_UnCaughtByFront value)? unCaughtByFront,
+    TResult Function(_Invalid value)? invalid,
+    required TResult orElse(),
+  }) {
+    if (invalid != null) {
+      return invalid(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _Invalid implements CustomException {
+  const factory _Invalid(final String maessage) = _$InvalidImpl;
+
+  String get maessage;
+  @JsonKey(ignore: true)
+  _$$InvalidImplCopyWith<_$InvalidImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/core/helper/result/result.dart
+++ b/lib/core/helper/result/result.dart
@@ -1,0 +1,20 @@
+sealed class Result<T, E extends Exception> {
+  const Result();
+}
+
+class Success<T, E extends Exception> extends Result<T, E> {
+  final T data;
+
+  const Success({
+    required this.data,
+  });
+}
+
+class Failure<T, E extends Exception> extends Result<T, E> {
+
+  final E exception;
+
+  const Failure({
+    required this.exception,
+  });
+}

--- a/lib/core/helper/usecase/use_case.dart
+++ b/lib/core/helper/usecase/use_case.dart
@@ -1,4 +1,6 @@
-import 'use_case_result.dart';
+import 'package:flutter_best_practice/core/helper/result/result.dart';
+
+import '../error_handling/custom_exception.dart';
 
 /*
 설명
@@ -11,5 +13,5 @@ import 'use_case_result.dart';
 
 // ignore: one_member_abstracts
 abstract class UseCase<T, P> {
-  Future<UseCaseResult<T>> call({required P params});
+  Future<Result<T, CustomException>> call({required P params});
 }

--- a/lib/domain/auth/auth_repository.dart
+++ b/lib/domain/auth/auth_repository.dart
@@ -1,7 +1,8 @@
 import 'package:flutter_best_practice/domain/auth/params/sign_in_params.dart';
 import 'package:flutter_best_practice/domain/auth/params/sign_up_params.dart';
 
-import '../../core/helper/repository/repository_result.dart';
+import '../../core/helper/error_handling/custom_exception.dart';
+import '../../core/helper/result/result.dart';
 import 'model/sign_in_model.dart';
 
 /*
@@ -15,7 +16,7 @@ import 'model/sign_in_model.dart';
  */
 
 abstract interface class AuthRepository {
-  Future<RepositoryResult<SignInModel>> signIn({required SignInParams params});
+  Future<Result<SignInModel, CustomException>> signIn({required SignInParams params});
 
-  Future<RepositoryResult<void>> signUp({required SignUpParams params});
+  Future<Result<void, CustomException>> signUp({required SignUpParams params});
 }

--- a/lib/domain/auth/use_case/sign_in_use_case.dart
+++ b/lib/domain/auth/use_case/sign_in_use_case.dart
@@ -1,11 +1,11 @@
+import 'package:flutter_best_practice/core/helper/result/result.dart';
 import 'package:flutter_best_practice/data/auth/auth_repository_impl.dart';
 import 'package:flutter_best_practice/domain/auth/auth_repository.dart';
 import 'package:flutter_best_practice/domain/auth/model/sign_in_model.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../../core/helper/repository/repository_result.dart';
+import '../../../core/helper/error_handling/custom_exception.dart';
 import '../../../core/helper/usecase/use_case.dart';
-import '../../../core/helper/usecase/use_case_result.dart';
 import '../params/sign_in_params.dart';
 
 /*
@@ -23,7 +23,7 @@ import '../params/sign_in_params.dart';
 
  */
 
-final signInUseCaseProvider = Provider((ref){
+final signInUseCaseProvider = Provider((ref) {
   return SignInUseCase(authRepository: ref.watch(authRepositoryProvider));
 });
 
@@ -35,15 +35,8 @@ class SignInUseCase implements UseCase<SignInModel, SignInParams> {
   }) : _authRepository = authRepository;
 
   @override
-  Future<UseCaseResult<SignInModel>> call(
+  Future<Result<SignInModel, CustomException>> call(
       {required SignInParams params}) async {
-    final result = await _authRepository.signIn(params: params);
-
-    return switch (result) {
-      SuccessRepositoryResult<SignInModel>() =>
-        SuccessUseCaseResult<SignInModel>(data: result.data),
-      FailureRepositoryResult<SignInModel>() =>
-        FailureUseCaseResult<SignInModel>(message: result.messages?[0])
-    };
+    return await _authRepository.signIn(params: params);
   }
 }

--- a/lib/domain/auth/use_case/sign_up_use_case.dart
+++ b/lib/domain/auth/use_case/sign_up_use_case.dart
@@ -1,10 +1,10 @@
+import 'package:flutter_best_practice/core/helper/result/result.dart';
 import 'package:flutter_best_practice/data/auth/auth_repository_impl.dart';
 import 'package:flutter_best_practice/domain/auth/auth_repository.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
-import '../../../core/helper/repository/repository_result.dart';
+import '../../../core/helper/error_handling/custom_exception.dart';
 import '../../../core/helper/usecase/use_case.dart';
-import '../../../core/helper/usecase/use_case_result.dart';
 import '../params/sign_up_params.dart';
 
 /*
@@ -34,13 +34,8 @@ class SignUpUseCase implements UseCase<void, SignUpParams> {
   }) : _authRepository = authRepository;
 
   @override
-  Future<UseCaseResult<void>> call({required SignUpParams params}) async {
-    final resp = await _authRepository.signUp(params: params);
-
-    return switch (resp) {
-      SuccessRepositoryResult<void>() => SuccessUseCaseResult<void>(data: null),
-      FailureRepositoryResult<void>() =>
-        FailureUseCaseResult<void>(message: resp.messages?[0])
-    };
+  Future<Result<void, CustomException>> call(
+      {required SignUpParams params}) async {
+    return await _authRepository.signUp(params: params);
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_best_practice/manager/app/app_manager_impl.dart';
 import 'package:flutter_best_practice/manager/router/app_router.dart';
-import 'package:flutter_best_practice/ui/auth/sign_in/sign_in_view.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 void main() {

--- a/lib/ui/auth/sign_in/sign_in_view_model.dart
+++ b/lib/ui/auth/sign_in/sign_in_view_model.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_best_practice/core/helper/error_handling/custom_exception.dart';
 import 'package:flutter_best_practice/core/status/loading_status.dart';
 import 'package:flutter_best_practice/domain/auth/use_case/sign_in_use_case.dart';
 import 'package:flutter_best_practice/manager/app/app_manager_impl.dart';
@@ -5,8 +6,8 @@ import 'package:flutter_best_practice/manager/app/interface/app_sign_in_able.dar
 import 'package:flutter_best_practice/ui/auth/sign_in/sign_in_state.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../core/helper/result/result.dart';
 import '../../../core/helper/usecase/use_case.dart';
-import '../../../core/helper/usecase/use_case_result.dart';
 import '../../../domain/auth/model/sign_in_model.dart';
 import '../../../domain/auth/params/sign_in_params.dart';
 
@@ -32,14 +33,12 @@ final signInViewModelProvider =
 });
 
 class SignInViewModel extends StateNotifier<SignInState> {
-  final UseCase<SignInModel, SignInParams> _signInUseCase;
   final AppSignInAble _appManager;
 
   SignInViewModel(
       {required UseCase<SignInModel, SignInParams> signInUseCase,
       required AppSignInAble appManager})
       : _appManager = appManager,
-        _signInUseCase = signInUseCase,
         super(SignInState.init());
 
   void updateEmail({required String email}) {
@@ -60,18 +59,14 @@ class SignInViewModel extends StateNotifier<SignInState> {
     await Future.delayed(const Duration(seconds: 2));
 
     // 성공하여서 다음과 같은 반환값을 받았다고 가정
-    const resp = SuccessUseCaseResult<SignInModel>(
+    const resp = Success<SignInModel, CustomException>(
         data: SignInModel(
             accessToken: 'accessToken', refreshToken: 'refreshToken'));
 
     switch (resp) {
-      case SuccessUseCaseResult<SignInModel>():
+      case Success<SignInModel, CustomException>():
         await _appManager.signIn(isSignIn: true);
         state = state.copyWith(signInLoadingStatus: LoadingStatus.success);
-      case FailureUseCaseResult<SignInModel>():
-        state = state.copyWith(
-          signInLoadingStatus: LoadingStatus.error,
-        );
     }
   }
 }

--- a/lib/ui/auth/sign_up/sign_up_view_model.dart
+++ b/lib/ui/auth/sign_up/sign_up_view_model.dart
@@ -27,10 +27,8 @@ final signUpViewModelProvider =
 });
 
 class SignUpViewModel extends StateNotifier<SignUpState> {
-  final UseCase<void, SignUpParams> _signUpUseCase;
   SignUpViewModel({required UseCase<void, SignUpParams> signUpUseCase})
-      : _signUpUseCase = signUpUseCase,
-        super(SignUpState.init());
+      : super(SignUpState.init());
 
   void updateEmail({required String email}) {
     state = state.copyWith(email: email);
@@ -52,17 +50,13 @@ class SignUpViewModel extends StateNotifier<SignUpState> {
     //         email: state.email!, password: state.password!, name: state.name!));
 
     // 네트워크 레이턴시가 2초정도라 가정
-    await Future.delayed(Duration(seconds: 2));
+    await Future.delayed(const Duration(seconds: 2));
     // 서버 요청 후 성공적으로 응답을 받아왔다고 가정
     const resp = SuccessUseCaseResult<void>(data: null);
 
     switch (resp) {
       case SuccessUseCaseResult<void>():
         state = state.copyWith(signUpLoadingStatus: LoadingStatus.success);
-      case FailureUseCaseResult<void>():
-        state = state.copyWith(
-          signUpLoadingStatus: LoadingStatus.error,
-        );
-    }
+      }
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -304,8 +304,16 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  freezed:
+    dependency: "direct dev"
+    description:
+      name: freezed
+      sha256: a434911f643466d78462625df76fd9eb13e57348ff43fe1f77bbe909522c67a1
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.2"
   freezed_annotation:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: freezed_annotation
       sha256: c2e2d632dd9b8a2b7751117abcfc2b4888ecfe181bd9fca7170d9ef02e595fe2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,6 +43,7 @@ dependencies:
   retrofit: ^4.1.0
   logger: ^2.4.0
   go_router: ^14.2.3
+  freezed_annotation: ^2.4.4
 
 dev_dependencies:
   flutter_test:
@@ -60,6 +61,7 @@ dev_dependencies:
   riverpod_lint: ^2.3.10
   json_serializable: ^6.8.0
   retrofit_generator: ^8.1.2
+  freezed: ^2.5.2
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION


# Description
- 에러 핸들링 로직을 개선합니다.
# Changes
- ErrorModel 추가
   - http error의 response body에 대응되는 데이터 모델을 추가하였습니다.
- Result 패턴 추가
   - Result 패턴이 이미 있습니다만 (RepositoryResult, UseCaseResult), 좀 더 단순화 하였습니다.
   - 서브클래스로 Failure, Success를 갖습니다.
- CustomException 타입 추가
   - sealed class CustomException type을 추가하였습니다.
      - 혹시 모를 패턴 매칭을 고려하여, 그리고 무분별한 상속과 구현을 피하기 위해 sealed class를 이용하였습니다.
      - 이 타입을 상속하여 다양한 exception 들을 정의할 수 있습니다.
- 에러 처리 모듈화
   - apiCall이라는 함수를 만들었습니다.
      - 파라미터로 전달받은 태스크를 수행하며, 수행 결과에 따라 Result(Success,Failure)를 반환합니다.
      - 이를 통해 api 요청 로직이 있는 곳에 try-catch를 이용한 예외처리 로직을 매번 동일하게 작성해줄 필요가 없어졌습니다.


# References
- [에러 핸들링 개선 관련](https://nomal-dev.tistory.com/6?category=1212201)
